### PR TITLE
Fix installation from non-registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ionic-img-viewer",
-    "version": "2.7",
+    "version": "2.7.0",
     "description": "Ionic 2 component providing a Twitter inspired experience to visualize pictures.",
     "main": "./dist/es2015/ionic-img-viewer.js",
     "typings": "./dist/es2015/ionic-img-viewer.d.ts",


### PR DESCRIPTION
If you do `npm i jianminLee/ionic-img-viewer` it will say there's no package.json. Turns out, it requires a valid semver version (Found this out by trying to install as a tarball).

This fix will make it install correctly.